### PR TITLE
Switch from Pathlib to os.path in plugin

### DIFF
--- a/src/flake8_no_pep420/__init__.py
+++ b/src/flake8_no_pep420/__init__.py
@@ -1,6 +1,6 @@
 import ast
+import os
 import sys
-from pathlib import Path
 from typing import Any, Generator, Tuple, Type
 
 if sys.version_info >= (3, 8):
@@ -14,13 +14,16 @@ class NoPep420Checker:
     version = version("flake8-no-pep420")
 
     def __init__(self, tree: ast.AST, filename: str) -> None:
-        self._path = Path(filename)
+        self._filename = filename
 
     def run(self) -> Generator[Tuple[int, int, str, Type[Any]], None, None]:
-        if self._path.name == "__init__.py":
+        dirname, basename = os.path.split(self._filename)
+
+        if basename == "__init__.py":
             return
 
-        if not (self._path.parent / "__init__.py").exists():
+        init_name = os.path.join(dirname, "__init__.py")
+        if not os.path.exists(init_name):
             yield (
                 1,
                 0,


### PR DESCRIPTION
It’s meant to be a little faster, especially since Flake8 isn’t handing us a `Path`.