### PR TITLE
Improve docs about tool problems

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,18 +45,25 @@ Rationale
 =========
 
 Implicit namespace packages are directories of Python files without an ``__init__.py``.
-They’re valid and importable, but they break *many* tools, such as:
+They’re valid and importable, but they break some tools:
 
-* `unittest test discovery <https://bugs.python.org/issue23882>`__ (and by extension, Django’s test runner)
-* `Coverage.py <https://github.com/nedbat/coveragepy/issues/1024>`__
-* Mypy without its `--namespace-packages option <https://mypy.readthedocs.io/en/latest/command_line.html#import-discovery>`__
-* `pytest <https://github.com/pytest-dev/pytest/issues/5147>`__
+* unittest test discovery, unless |-s (--start-directory)|__ points to the namespace package.
+  By extension, this affects Django’s test runner too.
+
+  .. |-s (--start-directory)| replace:: ``-s`` (``--start-directory``)
+  __ https://docs.python.org/3/library/unittest.html#cmdoption-unittest-discover-s
+
+* Coverage.py, unless |report.include_namespace_packages|__ is enabled.
+
+  .. |report.include_namespace_packages| replace:: ``report.include_namespace_packages``
+  __ https://coverage.readthedocs.io/en/latest/config.html#report-include-namespace-packages
+
+* pytest (`Issue #5147 <https://github.com/pytest-dev/pytest/issues/5147>`__)
 
 In most cases, tools fail silently, which can lead to a false sense of security:
 
 * Tests may look legitimate but never run
 * Code may be untested but not appear in coverage statistics
-* Types may never be checked
 
 PEP-420’s algorithm is non-trivial which is probably why such tools haven’t (yet) implemented it.
 


### PR DESCRIPTION
Remove Mypy because it enabled namespace discovery by default, and update how the others are presented.